### PR TITLE
Centralize entropy and affinity metrics utilities

### DIFF
--- a/arianna_core/entropy_resonance.py
+++ b/arianna_core/entropy_resonance.py
@@ -1,22 +1,13 @@
 import json
-import math
 import os
 from datetime import datetime
 import logging
 
 from . import mini_le
 from .config import is_enabled
+from .metrics import calculate_entropy
 
 LOG_FILE = os.path.join(os.path.dirname(__file__), "entropy.log")
-
-
-def calculate_entropy(text: str) -> float:
-    """Return Shannon entropy of ``text``."""
-    if not text:
-        return 0.0
-    freq = {c: text.count(c) / len(text) for c in set(text)}
-    return -sum(p * math.log2(p) for p in freq.values())
-
 
 def resonance_check(entropy: float, threshold: float = 4.0) -> bool:
     """Return ``True`` if ``entropy`` exceeds ``threshold``."""

--- a/arianna_core/metrics.py
+++ b/arianna_core/metrics.py
@@ -1,0 +1,32 @@
+"""Utility metrics for text analysis."""
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+# Default set of affinity words used across modules
+DEFAULT_AFFINITY_WORDS = ["resonance", "echo", "thunder", "love"]
+
+
+def calculate_entropy(text: str) -> float:
+    """Return the Shannon entropy of ``text``.
+
+    The value is ``0.0`` for empty strings.
+    """
+    if not text:
+        return 0.0
+    freq = {c: text.count(c) / len(text) for c in set(text)}
+    return -sum(p * math.log2(p) for p in freq.values())
+
+
+def calculate_affinity(text: str, words: Iterable[str] | None = None) -> float:
+    """Return the proportion of characters that belong to ``words``.
+
+    ``words`` defaults to :data:`DEFAULT_AFFINITY_WORDS`.
+    The value is ``0.0`` for empty strings.
+    """
+    if not text:
+        return 0.0
+    word_list = list(words) if words is not None else DEFAULT_AFFINITY_WORDS
+    lower = text.lower()
+    return sum(lower.count(w) for w in word_list) / len(text)

--- a/arianna_core/pain.py
+++ b/arianna_core/pain.py
@@ -1,10 +1,10 @@
-import math
 import random
 import importlib
 import logging
 
 from typing import Any
 from .config import is_enabled
+from .metrics import calculate_entropy, calculate_affinity
 
 _mini_le: Any = None
 MODEL_FILE: str = ""
@@ -19,22 +19,6 @@ def _load_refs():
         MODEL_FILE = _mini_le.MODEL_FILE
         LOG_FILE = _mini_le.LOG_FILE
     assert _mini_le is not None
-
-
-WORDS = ['resonance', 'echo', 'thunder', 'love']
-
-
-def calculate_affinity(output: str) -> float:
-    if not output:
-        return 0.0
-    return sum(output.lower().count(w) for w in WORDS) / len(output)
-
-
-def calculate_entropy(output: str) -> float:
-    if not output:
-        return 0.0
-    freq = {c: output.count(c) / len(output) for c in set(output)}
-    return -sum(p * math.log2(p) for p in freq.values())
 
 
 def trigger_pain(output: str, max_ent: float = 8.0) -> float:

--- a/arianna_core/skin.py
+++ b/arianna_core/skin.py
@@ -1,30 +1,12 @@
 import os
-import math
 from datetime import datetime
 import logging
 from .mini_le import load_model, generate
 from .config import is_enabled
+from .metrics import calculate_entropy, calculate_affinity
 
 INDEX_PATH = os.path.join(os.path.dirname(__file__), "..", "index.html")
 LOG_FILE = os.path.join(os.path.dirname(__file__), "log.txt")
-
-WORDS = ['resonance', 'echo', 'thunder', 'love']
-
-
-def calculate_entropy(text: str) -> float:
-    """Return Shannon entropy of ``text``."""
-    if not text:
-        return 0.0
-    freq = {c: text.count(c) / len(text) for c in set(text)}
-    return -sum(p * math.log2(p) for p in freq.values())
-
-
-def affinity(text: str) -> float:
-    """Return proportion of characters belonging to affinity words."""
-    if not text:
-        return 0.0
-    lower = text.lower()
-    return sum(lower.count(w) for w in WORDS) / len(text)
 
 
 def evolve_skin(index_path: str = INDEX_PATH) -> str:
@@ -35,7 +17,7 @@ def evolve_skin(index_path: str = INDEX_PATH) -> str:
     model = load_model() or {}
     output = generate(model, length=100)
     ent = calculate_entropy(output)
-    aff = affinity(output)
+    aff = calculate_affinity(output)
 
     ratio = max(0.0, min(ent / 6.0, 1.0))
     r = int(255 * ratio)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,26 @@
+import math
+import pytest
+
+from arianna_core import entropy_resonance, metrics, pain, skin
+
+
+def test_calculate_entropy_basic() -> None:
+    text = "aaaab"
+    expected = -(0.8 * math.log2(0.8) + 0.2 * math.log2(0.2))
+    assert metrics.calculate_entropy(text) == pytest.approx(expected)
+
+
+def test_calculate_affinity_default_and_custom() -> None:
+    text = "resonance echo"
+    assert metrics.calculate_affinity(text) == pytest.approx(2 / len(text))
+    assert metrics.calculate_affinity(text, ["resonance"]) == pytest.approx(
+        1 / len(text)
+    )
+
+
+def test_modules_use_shared_metrics() -> None:
+    assert entropy_resonance.calculate_entropy is metrics.calculate_entropy
+    assert pain.calculate_entropy is metrics.calculate_entropy
+    assert pain.calculate_affinity is metrics.calculate_affinity
+    assert skin.calculate_entropy is metrics.calculate_entropy
+    assert skin.calculate_affinity is metrics.calculate_affinity


### PR DESCRIPTION
## Summary
- add `metrics` module containing reusable `calculate_entropy` and `calculate_affinity`
- refactor `entropy_resonance`, `pain`, and `skin` modules to import shared metrics
- add tests exercising metrics and confirming modules use shared implementations

## Testing
- `ruff check arianna_core tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e59c351bc8329abfaf4292400d950