### PR TITLE
feat: support tomli fallback

### DIFF
--- a/arianna_core/config.py
+++ b/arianna_core/config.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 import os
 import pathlib
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Arianna Method" }]
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
 requires-python = ">=3.8"
-dependencies = ["regex"]
+dependencies = ["regex", "tomli; python_version < \"3.11\""]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- support Python <3.11 by falling back to `tomli` when `tomllib` is missing
- add conditional `tomli` dependency for older Python versions

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5ab18cc0832993a79c3d3b435239