### PR TITLE
Use deep copy for entropy mutation

### DIFF
--- a/arianna_core/entropy_resonance.py
+++ b/arianna_core/entropy_resonance.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 from datetime import datetime
@@ -18,7 +19,7 @@ def entropy_mutation(model: dict, sample: str) -> dict:
     """Boost model frequencies for characters present in ``sample``."""
     if not model:
         return model
-    mutated = json.loads(json.dumps(model))
+    mutated = copy.deepcopy(model)
     data = mutated["model"] if "model" in mutated else mutated
     for ch in set(sample):
         for ctx in data.values():

--- a/tests/test_entropy_resonance.py
+++ b/tests/test_entropy_resonance.py
@@ -1,0 +1,13 @@
+from arianna_core import entropy_resonance
+
+
+def test_entropy_mutation_deep_copy():
+    model = {"model": {"a": {"b": 1}}}
+    mutated = entropy_resonance.entropy_mutation(model, "b")
+    assert mutated is not model
+    assert mutated["model"] is not model["model"]
+    assert mutated["model"]["a"] is not model["model"]["a"]
+    assert model["model"]["a"]["b"] == 1
+    assert mutated["model"]["a"]["b"] == 2
+    mutated["model"]["a"]["b"] = 99
+    assert model["model"]["a"]["b"] == 1


### PR DESCRIPTION
## Summary
- use `copy.deepcopy` instead of JSON serialization when mutating models
- add regression test ensuring mutation works on a deep copy

## Testing
- `ruff check arianna_core/entropy_resonance.py tests/test_entropy_resonance.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5c62e05483299fe9224545e877cf