### PR TITLE
Use deepcopy for entropy mutation

### DIFF
--- a/arianna_core/entropy_resonance.py
+++ b/arianna_core/entropy_resonance.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 from datetime import datetime
@@ -18,7 +19,7 @@ def entropy_mutation(model: dict, sample: str) -> dict:
     """Boost model frequencies for characters present in ``sample``."""
     if not model:
         return model
-    mutated = json.loads(json.dumps(model))
+    mutated = copy.deepcopy(model)
     data = mutated["model"] if "model" in mutated else mutated
     for ch in set(sample):
         for ctx in data.values():

--- a/tests/test_entropy_resonance.py
+++ b/tests/test_entropy_resonance.py
@@ -1,0 +1,22 @@
+from arianna_core.entropy_resonance import entropy_mutation
+
+
+def test_entropy_mutation_preserves_structure_and_types() -> None:
+    model = {"model": {"ctx": {"a": 1}, 1: {"b": 2}}}
+    sample = "ab"
+    mutated = entropy_mutation(model, sample)
+
+    # Original model should remain unchanged
+    assert model == {"model": {"ctx": {"a": 1}, 1: {"b": 2}}}
+
+    # Mutated model should have incremented counts
+    assert mutated["model"]["ctx"]["a"] == 2
+    assert mutated["model"][1]["b"] == 3
+
+    # Key types should be preserved
+    assert 1 in mutated["model"]
+    assert "1" not in mutated["model"]
+
+    # Ensure deep copy (inner dicts are different objects)
+    assert mutated is not model
+    assert mutated["model"] is not model["model"]


### PR DESCRIPTION
## Summary
- replace JSON roundtripping with `copy.deepcopy` in `entropy_mutation`
- add test ensuring deep copies preserve structure and key types

## Testing
- `ruff check arianna_core tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5d59ba7c83298529a82a02341904