### PR TITLE
refactor mini_le into class-based API

### DIFF
--- a/arianna_core/entropy_resonance.py
+++ b/arianna_core/entropy_resonance.py
@@ -1,13 +1,14 @@
-import json
 import os
 from datetime import datetime
 import logging
+import json
 
-from . import mini_le
 from .config import is_enabled
 from .metrics import calculate_entropy
+from .mini_le import get_mini_le
 
 LOG_FILE = os.path.join(os.path.dirname(__file__), "entropy.log")
+mini_le = get_mini_le()
 
 def resonance_check(entropy: float, threshold: float = 4.0) -> bool:
     """Return ``True`` if ``entropy`` exceeds ``threshold``."""
@@ -36,7 +37,7 @@ def entropy_resonance_mutate(model: dict) -> tuple[dict, float, bool]:
     if resonance_check(ent):
         mutated = entropy_mutation(model, sample)
         changed = mutated != model
-    mini_le.rotate_log(LOG_FILE, mini_le.LOG_MAX_BYTES)
+    mini_le.rotate_log(LOG_FILE, mini_le.log_max_bytes)
     with open(LOG_FILE, "a", encoding="utf-8") as f:
         f.write(
             f"{datetime.utcnow().isoformat()} entropy={ent:.2f} "
@@ -54,5 +55,5 @@ def run_once() -> None:
     mutated, ent, changed = entropy_resonance_mutate(model)
     mini_le.last_entropy = ent
     if changed:
-        with open(mini_le.MODEL_FILE, "w", encoding="utf-8") as f:
+        with open(mini_le.model_file, "w", encoding="utf-8") as f:
             json.dump(mutated, f)

--- a/arianna_core/mini_le.py
+++ b/arianna_core/mini_le.py
@@ -5,233 +5,332 @@ import gzip
 import sqlite3
 from datetime import datetime
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "datasets")
-MODEL_FILE = os.path.join(os.path.dirname(__file__), "model.txt")
-LOG_FILE = os.path.join(os.path.dirname(__file__), "log.txt")
-HUMAN_LOG = os.path.join(os.path.dirname(__file__), "humanbridge.log")
+
 LOG_MAX_BYTES = 1_000_000
 LOG_KEEP = 3
 NGRAM_LEVEL = 2
-last_entropy: float = 0.0
-DB_FILE = os.path.join(os.path.dirname(__file__), "memory.db")
-LAST_REPRO_FILE = os.path.join(os.path.dirname(__file__), "last_reproduction.txt")
-BAD_WORDS = {"badword", "curse"}
-blocked_messages = 0
-last_novelty = 0.0
 
 
-def rotate_log(
-    path: str, max_bytes: int = LOG_MAX_BYTES, keep: int = LOG_KEEP
-) -> None:
-    """Archive ``path`` when it exceeds ``max_bytes`` and prune old
-    archives."""
-    if not os.path.exists(path) or os.path.getsize(path) < max_bytes:
-        return
-    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    archive = f"{path}.{ts}.gz"
-    with open(path, "rb") as src, gzip.open(archive, "wb") as dst:
-        dst.write(src.read())
-    os.remove(path)
+class MiniLE:
+    """Encapsulates the minimal language engine state and operations."""
 
-    base = os.path.basename(path)
-    dir_path = os.path.dirname(path)
-    archives = sorted(
-        [
-            f
-            for f in os.listdir(dir_path)
-            if f.startswith(base) and f.endswith(".gz")
-        ],
-        reverse=True,
-    )
-    for old in archives[keep:]:
-        os.remove(os.path.join(dir_path, old))
+    def __init__(
+        self,
+        data_dir: str | None = None,
+        model_file: str | None = None,
+        log_file: str | None = None,
+        human_log: str | None = None,
+        db_file: str | None = None,
+        last_repro_file: str | None = None,
+        ngram_level: int = NGRAM_LEVEL,
+        log_max_bytes: int = LOG_MAX_BYTES,
+        log_keep: int = LOG_KEEP,
+        bad_words: set[str] | None = None,
+    ) -> None:
+        root = os.path.dirname(__file__)
+        self.data_dir = data_dir or os.path.join(root, "..", "datasets")
+        self.model_file = model_file or os.path.join(root, "model.txt")
+        self.log_file = log_file or os.path.join(root, "log.txt")
+        self.human_log = human_log or os.path.join(root, "humanbridge.log")
+        self.db_file = db_file or os.path.join(root, "memory.db")
+        self.last_repro_file = last_repro_file or os.path.join(
+            root, "last_reproduction.txt"
+        )
+        self.ngram_level = ngram_level
+        self.log_max_bytes = log_max_bytes
+        self.log_keep = log_keep
+        self.bad_words = bad_words or {"badword", "curse"}
+        self.last_entropy: float = 0.0
+        self.blocked_messages = 0
+        self.last_novelty = 0.0
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    def rotate_log(
+        self, path: str, max_bytes: int | None = None, keep: int | None = None
+    ) -> None:
+        """Archive ``path`` when it exceeds ``max_bytes`` and prune old archives."""
+        max_b = max_bytes or self.log_max_bytes
+        keep_n = keep or self.log_keep
+        if not os.path.exists(path) or os.path.getsize(path) < max_b:
+            return
+        ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        archive = f"{path}.{ts}.gz"
+        with open(path, "rb") as src, gzip.open(archive, "wb") as dst:
+            dst.write(src.read())
+        os.remove(path)
+
+        base = os.path.basename(path)
+        dir_path = os.path.dirname(path)
+        archives = sorted(
+            [
+                f
+                for f in os.listdir(dir_path)
+                if f.startswith(base) and f.endswith(".gz")
+            ],
+            reverse=True,
+        )
+        for old in archives[keep_n:]:
+            os.remove(os.path.join(dir_path, old))
+
+    # ------------------------------------------------------------------
+    # Core model operations
+    def load_data(self) -> str:
+        """Return concatenated text from files in ``data_dir``."""
+        chunks: list[str] = []
+        if os.path.isdir(self.data_dir):
+            for name in os.listdir(self.data_dir):
+                path = os.path.join(self.data_dir, name)
+                if os.path.isfile(path):
+                    with open(path, "r", encoding="utf-8") as f:
+                        chunks.append(f.read())
+        return "\n".join(chunks)
+
+    def train(self, text: str, n: int | None = None) -> dict:
+        """Train an n-gram model from ``text`` and write it to ``model_file``."""
+        n = n or self.ngram_level
+        model: dict[str, dict[str, int]] = {}
+        for i in range(len(text) - n + 1):
+            ctx = text[i : i + n - 1]
+            ch = text[i + n - 1]
+            freq = model.setdefault(ctx, {})
+            freq[ch] = freq.get(ch, 0) + 1
+        data = {"n": n, "model": model}
+        with open(self.model_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return data
+
+    def load_model(self) -> dict | None:
+        if not os.path.exists(self.model_file):
+            return None
+        with open(self.model_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def generate(
+        self, model: dict, length: int = 80, seed: str | None = None
+    ) -> str:
+        """Generate ``length`` characters from ``model``."""
+        if not model:
+            return ""
+        n = model.get("n", 2)
+        m = model.get("model", {})
+        rng = random
+        if not m:
+            return ""
+        context = seed[-(n - 1) :] if seed else rng.choice(list(m.keys()))
+        output = context
+        for _ in range(length - len(context)):
+            freq = m.get(context)
+            if not freq:
+                context = rng.choice(list(m.keys()))
+                output += context
+                if len(output) >= length:
+                    break
+                continue
+            chars = list(freq.keys())
+            weights = list(freq.values())
+            ch = rng.choices(chars, weights=weights)[0]
+            output += ch
+            context = output[-(n - 1) :]
+        return output[:length]
+
+    def chat_response(self, message: str) -> str:
+        """Return a generated reply to ``message`` using the saved model."""
+        model = self.load_model()
+        if model is None:
+            model = self.train(self.load_data(), n=self.ngram_level)
+        return self.generate(model, length=60, seed=message)
+
+    # ------------------------------------------------------------------
+    # Pattern memory operations
+    def _init_db(self) -> sqlite3.Connection:
+        """Return a connection to the pattern memory database."""
+        conn = sqlite3.connect(self.db_file)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS patterns (pattern TEXT PRIMARY KEY, count INTEGER)"
+        )
+        return conn
+
+    def update_pattern_memory(self, text: str, n: int | None = None) -> None:
+        """Add n-gram patterns from ``text`` to ``memory.db``."""
+        n = n or self.ngram_level
+        conn = self._init_db()
+        rows: list[str] = []
+        for i in range(len(text) - n + 1):
+            rows.append(text[i : i + n])
+        with conn:
+            for pat in rows:
+                conn.execute(
+                    "INSERT INTO patterns(pattern, count) VALUES(?,1) "
+                    "ON CONFLICT(pattern) DO UPDATE SET count = count + 1",
+                    (pat,),
+                )
+        conn.close()
+
+    def maintain_pattern_memory(
+        self, threshold: int = 1, max_rows: int = 1000
+    ) -> None:
+        """Prune low-frequency patterns and cap table size."""
+        conn = self._init_db()
+        with conn:
+            conn.execute("DELETE FROM patterns WHERE count < ?", (threshold,))
+            cur = conn.execute(
+                "SELECT pattern, count FROM patterns ORDER BY count DESC"
+            )
+            rows = cur.fetchall()
+            if len(rows) > max_rows:
+                for pat, _ in rows[max_rows:]:
+                    conn.execute(
+                        "DELETE FROM patterns WHERE pattern = ?", (pat,)
+                    )
+        conn.close()
+
+    def metabolize_input(self, text: str, n: int | None = None) -> float:
+        """Return novelty score between 0 and 1 for ``text``."""
+        n = n or self.ngram_level
+        conn = self._init_db()
+        unseen = 0
+        total = 0
+        for i in range(len(text) - n + 1):
+            pat = text[i : i + n]
+            total += 1
+            cur = conn.execute(
+                "SELECT 1 FROM patterns WHERE pattern = ? LIMIT 1", (pat,)
+            )
+            if cur.fetchone() is None:
+                unseen += 1
+        conn.close()
+        score = unseen / total if total else 0.0
+        self.last_novelty = score
+        return score
+
+    def immune_filter(self, text: str) -> str:
+        """Return ``""`` if ``text`` contains banned words."""
+        tokens = [t.lower() for t in text.split()]
+        if any(t in self.bad_words for t in tokens):
+            self.blocked_messages += 1
+            return ""
+        return text
+
+    def adaptive_mutation(self, model: dict) -> dict:
+        """Randomly tweak model weights if novelty improves."""
+        if not model or not model.get("model"):
+            return model
+        before = self.generate(model, length=40)
+        score_before = self.metabolize_input(before)
+        ctx = random.choice(list(model["model"].keys()))
+        freq = model["model"][ctx]
+        ch = random.choice(list(freq.keys()))
+        old = freq[ch]
+        freq[ch] = max(1, old + random.choice([-1, 1]))
+        after = self.generate(model, length=40)
+        score_after = self.metabolize_input(after)
+        if score_after < score_before:
+            freq[ch] = old
+        return model
+
+    def reproduction_cycle(
+        self, threshold: int = 1, max_rows: int = 1000
+    ) -> dict:
+        """Retrain model, update memory and apply mutation."""
+        text = self.load_data()
+        model = self.train(text, n=self.ngram_level)
+        self.update_pattern_memory(text)
+        self.maintain_pattern_memory(
+            threshold=threshold, max_rows=max_rows
+        )
+        model = self.adaptive_mutation(model)
+        ts = datetime.utcnow().isoformat()
+        with open(self.last_repro_file, "w", encoding="utf-8") as f:
+            f.write(ts)
+        return model
+
+    def health_report(self) -> dict:
+        """Return health metrics about the system."""
+        conn = self._init_db()
+        cur = conn.execute("SELECT COUNT(*) FROM patterns")
+        mem_rows = cur.fetchone()[0]
+        conn.close()
+        model = self.load_model()
+        model_size = len(model.get("model", {})) if model else 0
+        last_rep = None
+        if os.path.exists(self.last_repro_file):
+            with open(self.last_repro_file, "r", encoding="utf-8") as f:
+                last_rep = f.read().strip()
+        return {
+            "model_size": model_size,
+            "pattern_memory": mem_rows,
+            "blocked_messages": self.blocked_messages,
+            "novelty": self.last_novelty,
+            "last_reproduction": last_rep,
+        }
+
+
+_INSTANCE: MiniLE | None = None
+
+
+def get_mini_le() -> MiniLE:
+    """Return a module-wide ``MiniLE`` instance."""
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = MiniLE()
+    return _INSTANCE
+
+
+# ----------------------------------------------------------------------
+# Backwards-compatible function wrappers
+
+
+def rotate_log(path: str, max_bytes: int = LOG_MAX_BYTES, keep: int = LOG_KEEP) -> None:
+    get_mini_le().rotate_log(path, max_bytes=max_bytes, keep=keep)
 
 
 def load_data() -> str:
-    """Return concatenated text from files in ``DATA_DIR``."""
-    chunks = []
-    if os.path.isdir(DATA_DIR):
-        for name in os.listdir(DATA_DIR):
-            path = os.path.join(DATA_DIR, name)
-            if os.path.isfile(path):
-                with open(path, "r", encoding="utf-8") as f:
-                    chunks.append(f.read())
-    return "\n".join(chunks)
+    return get_mini_le().load_data()
 
 
 def train(text: str, n: int = NGRAM_LEVEL) -> dict:
-    """Train an n-gram model from ``text`` and write it to ``MODEL_FILE``."""
-    model: dict[str, dict[str, int]] = {}
-    for i in range(len(text) - n + 1):
-        ctx = text[i:i + n - 1]
-        ch = text[i + n - 1]
-        freq = model.setdefault(ctx, {})
-        freq[ch] = freq.get(ch, 0) + 1
-    data = {"n": n, "model": model}
-    with open(MODEL_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f)
-    return data
+    return get_mini_le().train(text, n=n)
 
 
 def load_model() -> dict | None:
-    if not os.path.exists(MODEL_FILE):
-        return None
-    with open(MODEL_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    return get_mini_le().load_model()
 
 
 def generate(model: dict, length: int = 80, seed: str | None = None) -> str:
-    """Generate ``length`` characters from ``model``."""
-    if not model:
-        return ""
-    n = model.get("n", 2)
-    m = model.get("model", {})
-    rng = random
-    if not m:
-        return ""
-    context = seed[-(n - 1):] if seed else rng.choice(list(m.keys()))
-    output = context
-    for _ in range(length - len(context)):
-        freq = m.get(context)
-        if not freq:
-            context = rng.choice(list(m.keys()))
-            output += context
-            if len(output) >= length:
-                break
-            continue
-        chars = list(freq.keys())
-        weights = list(freq.values())
-        ch = rng.choices(chars, weights=weights)[0]
-        output += ch
-        context = output[-(n - 1):]
-    return output[:length]
+    return get_mini_le().generate(model, length=length, seed=seed)
 
 
 def chat_response(message: str) -> str:
-    """Return a generated reply to ``message`` using the saved model."""
-    model = load_model()
-    if model is None:
-        model = train(load_data(), n=NGRAM_LEVEL)
-    return generate(model, length=60, seed=message)
-
-
-def _init_db() -> sqlite3.Connection:
-    """Return a connection to the pattern memory database."""
-    conn = sqlite3.connect(DB_FILE)
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS patterns (pattern TEXT PRIMARY KEY, count INTEGER)"
-    )
-    return conn
+    return get_mini_le().chat_response(message)
 
 
 def update_pattern_memory(text: str, n: int = NGRAM_LEVEL) -> None:
-    """Add n-gram patterns from ``text`` to ``memory.db``."""
-    conn = _init_db()
-    rows = []
-    for i in range(len(text) - n + 1):
-        rows.append(text[i : i + n])
-    with conn:
-        for pat in rows:
-            conn.execute(
-                "INSERT INTO patterns(pattern, count) VALUES(?,1) "
-                "ON CONFLICT(pattern) DO UPDATE SET count = count + 1",
-                (pat,),
-            )
-    conn.close()
+    get_mini_le().update_pattern_memory(text, n=n)
 
 
 def maintain_pattern_memory(threshold: int = 1, max_rows: int = 1000) -> None:
-    """Prune low-frequency patterns and cap table size."""
-    conn = _init_db()
-    with conn:
-        conn.execute("DELETE FROM patterns WHERE count < ?", (threshold,))
-        cur = conn.execute(
-            "SELECT pattern, count FROM patterns ORDER BY count DESC"
-        )
-        rows = cur.fetchall()
-        if len(rows) > max_rows:
-            for pat, _ in rows[max_rows:]:
-                conn.execute("DELETE FROM patterns WHERE pattern = ?", (pat,))
-    conn.close()
+    get_mini_le().maintain_pattern_memory(threshold=threshold, max_rows=max_rows)
 
 
 def metabolize_input(text: str, n: int = NGRAM_LEVEL) -> float:
-    """Return novelty score between 0 and 1 for ``text``."""
-    global last_novelty
-    conn = _init_db()
-    unseen = 0
-    total = 0
-    for i in range(len(text) - n + 1):
-        pat = text[i : i + n]
-        total += 1
-        cur = conn.execute(
-            "SELECT 1 FROM patterns WHERE pattern = ? LIMIT 1", (pat,)
-        )
-        if cur.fetchone() is None:
-            unseen += 1
-    conn.close()
-    score = unseen / total if total else 0.0
-    last_novelty = score
-    return score
+    return get_mini_le().metabolize_input(text, n=n)
 
 
 def immune_filter(text: str) -> str:
-    """Return ``""`` if ``text`` contains banned words."""
-    global blocked_messages
-    tokens = [t.lower() for t in text.split()]
-    if any(t in BAD_WORDS for t in tokens):
-        blocked_messages += 1
-        return ""
-    return text
+    return get_mini_le().immune_filter(text)
 
 
 def adaptive_mutation(model: dict) -> dict:
-    """Randomly tweak model weights if novelty improves."""
-    if not model or not model.get("model"):
-        return model
-    before = generate(model, length=40)
-    score_before = metabolize_input(before)
-    ctx = random.choice(list(model["model"].keys()))
-    freq = model["model"][ctx]
-    ch = random.choice(list(freq.keys()))
-    old = freq[ch]
-    freq[ch] = max(1, old + random.choice([-1, 1]))
-    after = generate(model, length=40)
-    score_after = metabolize_input(after)
-    if score_after < score_before:
-        freq[ch] = old
-    return model
+    return get_mini_le().adaptive_mutation(model)
 
 
 def reproduction_cycle(threshold: int = 1, max_rows: int = 1000) -> dict:
-    """Retrain model, update memory and apply mutation."""
-    text = load_data()
-    model = train(text, n=NGRAM_LEVEL)
-    update_pattern_memory(text)
-    maintain_pattern_memory(threshold=threshold, max_rows=max_rows)
-    model = adaptive_mutation(model)
-    ts = datetime.utcnow().isoformat()
-    with open(LAST_REPRO_FILE, "w", encoding="utf-8") as f:
-        f.write(ts)
-    return model
+    return get_mini_le().reproduction_cycle(
+        threshold=threshold, max_rows=max_rows
+    )
 
 
 def health_report() -> dict:
-    """Return health metrics about the system."""
-    conn = _init_db()
-    cur = conn.execute("SELECT COUNT(*) FROM patterns")
-    mem_rows = cur.fetchone()[0]
-    conn.close()
-    model = load_model()
-    model_size = len(model.get("model", {})) if model else 0
-    last_rep = None
-    if os.path.exists(LAST_REPRO_FILE):
-        with open(LAST_REPRO_FILE, "r", encoding="utf-8") as f:
-            last_rep = f.read().strip()
-    return {
-        "model_size": model_size,
-        "pattern_memory": mem_rows,
-        "blocked_messages": blocked_messages,
-        "novelty": last_novelty,
-        "last_reproduction": last_rep,
-    }
+    return get_mini_le().health_report()
+

--- a/arianna_core/server.py
+++ b/arianna_core/server.py
@@ -5,17 +5,13 @@ import json
 import os
 import sys
 
-from typing import TYPE_CHECKING
-
 if __package__ is None:
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-    import importlib
-    mini_le = importlib.import_module("arianna_core.mini_le")  # type: ignore
+    from arianna_core.mini_le import get_mini_le  # type: ignore
 else:
-    from . import mini_le
+    from .mini_le import get_mini_le
 
-if TYPE_CHECKING:
-    from . import mini_le as _mini_le_mod  # noqa: F401
+mini_le = get_mini_le()
 
 ROOT = os.path.join(os.path.dirname(__file__), "..")
 
@@ -52,7 +48,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.end_headers()
             data = {
                 "status": "alive",
-                "entropy": getattr(mini_le, "last_entropy", 0.0),
+                "entropy": mini_le.last_entropy,
             }
             self.wfile.write(json.dumps(data).encode("utf-8"))
         else:

--- a/arianna_core/skin.py
+++ b/arianna_core/skin.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 import logging
-from .mini_le import load_model, generate
+from .mini_le import get_mini_le
 from .config import is_enabled
 from .metrics import calculate_entropy, calculate_affinity
 
@@ -14,8 +14,9 @@ def evolve_skin(index_path: str = INDEX_PATH) -> str:
     if not is_enabled("skin"):
         logging.info("[skin] feature disabled, skipping")
         return ""
-    model = load_model() or {}
-    output = generate(model, length=100)
+    le = get_mini_le()
+    model = le.load_model() or {}
+    output = le.generate(model, length=100)
     ent = calculate_entropy(output)
     aff = calculate_affinity(output)
 

--- a/genesis.py
+++ b/genesis.py
@@ -2,12 +2,16 @@ import os
 import json
 import random
 import argparse
-from arianna_core import mini_le, entropy_resonance
+from arianna_core.mini_le import get_mini_le
+from arianna_core import entropy_resonance
+
+
+le = get_mini_le()
 
 
 def load_logs():
     text = ""
-    for path in [mini_le.LOG_FILE, mini_le.HUMAN_LOG]:
+    for path in [le.log_file, le.human_log]:
         if os.path.exists(path):
             with open(path, "r", encoding="utf-8") as f:
                 text += f.read() + "\n"
@@ -15,18 +19,18 @@ def load_logs():
 
 
 def main(chaos: bool = False, entropy: bool = False):
-    base = mini_le.load_data()
+    base = le.load_data()
     logs = load_logs()
     if chaos:
         lines = logs.splitlines()
         random.shuffle(lines)
         logs = "\n".join(lines)
-    model = mini_le.train(base + logs)
+    model = le.train(base + logs)
     if entropy:
-        model = mini_le.reproduction_cycle()
+        model = le.reproduction_cycle()
         model, ent, changed = entropy_resonance.entropy_resonance_mutate(model)
         if changed:
-            with open(mini_le.MODEL_FILE, "w", encoding="utf-8") as f:
+            with open(le.model_file, "w", encoding="utf-8") as f:
                 json.dump(model, f)
 
 

--- a/tests/test_mini_le.py
+++ b/tests/test_mini_le.py
@@ -1,76 +1,78 @@
 from arianna_core import mini_le
 
 
-def test_train_and_generate(tmp_path, monkeypatch):
+def test_train_and_generate(tmp_path):
     model_file = tmp_path / "model.txt"
-    monkeypatch.setattr(mini_le, "MODEL_FILE", str(model_file))
-    model = mini_le.train("abba", n=2)
+    le = mini_le.MiniLE(model_file=str(model_file))
+    model = le.train("abba", n=2)
     assert model_file.exists()
-    out = mini_le.generate(model, length=4, seed="a")
+    out = le.generate(model, length=4, seed="a")
     assert out
 
 
-def test_load_data(tmp_path, monkeypatch):
+def test_load_data(tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "f.txt").write_text("abc", encoding="utf-8")
-    monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
-    text = mini_le.load_data()
+    le = mini_le.MiniLE(data_dir=str(data_dir))
+    text = le.load_data()
     assert "abc" in text
 
 
-def test_chat_response(tmp_path, monkeypatch):
+def test_chat_response(tmp_path):
     model_file = tmp_path / "model.txt"
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     (data_dir / "f.txt").write_text("abcabc", encoding="utf-8")
-    monkeypatch.setattr(mini_le, "MODEL_FILE", str(model_file))
-    monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
-    reply = mini_le.chat_response("a")
+    le = mini_le.MiniLE(model_file=str(model_file), data_dir=str(data_dir))
+    reply = le.chat_response("a")
     assert isinstance(reply, str) and reply
 
 
-def test_reproduction_and_report(tmp_path, monkeypatch):
+def test_reproduction_and_report(tmp_path):
     model_file = tmp_path / "model.txt"
     data_dir = tmp_path / "data"
     db_file = tmp_path / "memory.db"
     repro_file = tmp_path / "last.txt"
     data_dir.mkdir()
     (data_dir / "d.txt").write_text("abcd" * 3, encoding="utf-8")
-    monkeypatch.setattr(mini_le, "MODEL_FILE", str(model_file))
-    monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
-    monkeypatch.setattr(mini_le, "DB_FILE", str(db_file))
-    monkeypatch.setattr(mini_le, "LAST_REPRO_FILE", str(repro_file))
-    mini_le.reproduction_cycle(threshold=1, max_rows=10)
+    le = mini_le.MiniLE(
+        model_file=str(model_file),
+        data_dir=str(data_dir),
+        db_file=str(db_file),
+        last_repro_file=str(repro_file),
+    )
+    le.reproduction_cycle(threshold=1, max_rows=10)
     assert db_file.exists()
-    report = mini_le.health_report()
+    report = le.health_report()
     assert report["model_size"] > 0
     assert report["pattern_memory"] > 0
     assert report["last_reproduction"]
 
 
-def test_metabolize_and_filter(tmp_path, monkeypatch):
+def test_metabolize_and_filter(tmp_path):
     db_file = tmp_path / "memory.db"
-    monkeypatch.setattr(mini_le, "DB_FILE", str(db_file))
-    mini_le.update_pattern_memory("abab", n=2)
-    assert mini_le.metabolize_input("abab", n=2) == 0.0
-    assert mini_le.metabolize_input("zzzz", n=2) > 0.0
-    mini_le.blocked_messages = 0
-    assert mini_le.immune_filter("badword") == ""
-    assert mini_le.blocked_messages == 1
+    le = mini_le.MiniLE(db_file=str(db_file))
+    le.update_pattern_memory("abab", n=2)
+    assert le.metabolize_input("abab", n=2) == 0.0
+    assert le.metabolize_input("zzzz", n=2) > 0.0
+    le.blocked_messages = 0
+    assert le.immune_filter("badword") == ""
+    assert le.blocked_messages == 1
 
 
-def test_rotate_log(tmp_path, monkeypatch):
+def test_rotate_log(tmp_path):
     log = tmp_path / "log.txt"
     log.write_bytes(b"x" * 10)
-    mini_le.rotate_log(str(log), max_bytes=1, keep=2)
+    le = mini_le.MiniLE()
+    le.rotate_log(str(log), max_bytes=1, keep=2)
     archives = list(tmp_path.glob("log.txt.*.gz"))
     assert not log.exists()
     assert len(archives) == 1
     # rotate twice more to trigger pruning
-    for i in range(2):
+    for _ in range(2):
         new_log = tmp_path / "log.txt"
         new_log.write_bytes(b"y" * 10)
-        mini_le.rotate_log(str(new_log), max_bytes=1, keep=2)
+        le.rotate_log(str(new_log), max_bytes=1, keep=2)
     archives = list(tmp_path.glob("log.txt.*.gz"))
     assert len(archives) <= 2


### PR DESCRIPTION
## Summary
- wrap mini_le functionality in a MiniLE class with stateful paths and counters
- expose get_mini_le() accessor and compatibility wrappers
- update server and ancillary modules to use the MiniLE instance
- adjust tests to instantiate MiniLE directly

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5bc1654883298592482e85911727