### PR TITLE
refactor: move json dump import to module scope in pain

### DIFF
--- a/arianna_core/pain.py
+++ b/arianna_core/pain.py
@@ -1,6 +1,7 @@
 import random
 import importlib
 import logging
+from json import dump
 
 from typing import Any
 from .config import is_enabled
@@ -27,8 +28,6 @@ def trigger_pain(output: str, max_ent: float = 8.0) -> float:
         logging.info("[pain] feature disabled, skipping")
         return 0.0
     _load_refs()
-    from json import dump
-
     aff = calculate_affinity(output)
     ent = calculate_entropy(output)
     score = (1 - aff) * (max_ent - ent)


### PR DESCRIPTION
## Summary
- import `dump` from `json` at module level in `arianna_core.pain`
- remove redundant local import in `trigger_pain`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5d7204c88329addc1c30c0944636