### PR TITLE
refactor server import and module execution

### DIFF
--- a/arianna_core/server.py
+++ b/arianna_core/server.py
@@ -7,12 +7,7 @@ import sys
 
 from typing import TYPE_CHECKING
 
-if __package__ is None:
-    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-    import importlib
-    mini_le = importlib.import_module("arianna_core.mini_le")  # type: ignore
-else:
-    from . import mini_le
+from . import mini_le
 
 if TYPE_CHECKING:
     from . import mini_le as _mini_le_mod  # noqa: F401
@@ -82,8 +77,8 @@ def serve(port: int = 8000) -> None:
     HTTPServer(("", port), handler).serve_forever()
 
 
-if __name__ == "__main__":
-    import sys
-
+if __name__ == "__main__":  # pragma: no cover
+    if __package__ is None or __package__ == "":
+        raise SystemExit("Run this module with `python -m arianna_core.server`.")
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
     serve(port)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 import json
+import os
 
 from arianna_core import server
 
@@ -82,13 +83,12 @@ def test_root_serves_index(monkeypatch):
     assert "<!DOCTYPE html>" in body
 
 
-def test_server_runs_as_script(tmp_path):
+def test_server_runs_as_module():
     port = 8765
-    proc = subprocess.Popen([
-        sys.executable,
-        "arianna_core/server.py",
-        str(port),
-    ], cwd=str(ROOT))
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "arianna_core.server", str(port)],
+        cwd=str(ROOT),
+    )
     try:
         time.sleep(0.3)
         conn = http.client.HTTPConnection("localhost", port)
@@ -105,12 +105,13 @@ def test_server_runs_as_script(tmp_path):
 
 def test_server_root_from_temp_dir(tmp_path):
     port = 8766
-    script = ROOT / "arianna_core" / "server.py"
-    proc = subprocess.Popen([
-        sys.executable,
-        str(script),
-        str(port),
-    ], cwd=str(tmp_path))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "arianna_core.server", str(port)],
+        cwd=str(tmp_path),
+        env=env,
+    )
     try:
         time.sleep(0.3)
         conn = http.client.HTTPConnection("localhost", port)


### PR DESCRIPTION
## Summary
- simplify `server` package import by removing path hacks and using a direct relative import
- restrict server startup to module execution with `python -m arianna_core.server`
- adjust tests to invoke the server as a module and support running from other directories

## Testing
- `ruff check arianna_core/server.py tests/test_server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5d37ec1c8329907f1adcd324c0b3