### PR TITLE
Use configurable n-gram level

### DIFF
--- a/tests/test_mini_le.py
+++ b/tests/test_mini_le.py
@@ -26,6 +26,7 @@ def test_chat_response(tmp_path, monkeypatch):
     (data_dir / "f.txt").write_text("abcabc", encoding="utf-8")
     monkeypatch.setattr(mini_le, "MODEL_FILE", str(model_file))
     monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(mini_le.settings, "n_gram_level", 2)
     reply = mini_le.chat_response("a")
     assert isinstance(reply, str) and reply
 
@@ -41,6 +42,7 @@ def test_reproduction_and_report(tmp_path, monkeypatch):
     monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
     monkeypatch.setattr(mini_le, "DB_FILE", str(db_file))
     monkeypatch.setattr(mini_le, "LAST_REPRO_FILE", str(repro_file))
+    monkeypatch.setattr(mini_le.settings, "n_gram_level", 2)
     mini_le.reproduction_cycle(threshold=1, max_rows=10)
     assert db_file.exists()
     report = mini_le.health_report()


### PR DESCRIPTION
## Summary
- read configurable n-gram level from `arianna_core.config.settings`
- use the setting when training, chatting, tracking patterns and novelty
- patch `settings.n_gram_level` in tests via `monkeypatch`

## Testing
- `ruff check arianna_core/mini_le.py tests/test_mini_le.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5d84fff88329a58726e575730a52