### PR TITLE
Add bone memory system with metabolic push integration

### DIFF
--- a/arianna_core/memory/__init__.py
+++ b/arianna_core/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory subsystem for tracking event frequencies."""
+
+from .bone_memory import BoneMemory
+
+__all__ = ["BoneMemory"]

--- a/arianna_core/memory/bone_memory.py
+++ b/arianna_core/memory/bone_memory.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class BoneMemory:
+    """Track recent events and compute a metabolic push coefficient."""
+
+    limit: int
+    events: List[str] = field(default_factory=list)
+    metabolic_push: float = 0.0
+
+    def on_event(self, event_type: str) -> float:
+        """Record an event and update ``metabolic_push``.
+
+        The coefficient is the fraction of events of ``event_type`` in the
+        current window defined by ``limit``.
+        """
+        self.events.append(event_type)
+        if len(self.events) > self.limit:
+            # keep only the most recent ``limit`` events
+            self.events = self.events[-self.limit:]
+        count = self.events.count(event_type)
+        self.metabolic_push = count / len(self.events) if self.events else 0.0
+        return self.metabolic_push

--- a/tests/test_bone_memory.py
+++ b/tests/test_bone_memory.py
@@ -1,0 +1,26 @@
+from arianna_core.memory.bone_memory import BoneMemory
+from arianna_core import mini_le
+
+
+def test_bone_memory_window_and_push():
+    mem = BoneMemory(limit=2)
+    assert mem.on_event("x") == 1.0
+    assert mem.on_event("y") == 0.5
+    assert mem.on_event("y") == 1.0
+    assert mem.events == ["y", "y"]
+
+
+def test_chat_response_uses_bone_memory(tmp_path, monkeypatch):
+    mem = BoneMemory(limit=5)
+    monkeypatch.setattr(mini_le, "bone_memory", mem)
+    monkeypatch.setattr(
+        mini_le,
+        "_cached_model",
+        {"n": 2, "model": {"a": {"a": 1}}},
+    )
+    db_file = tmp_path / "memory.db"
+    monkeypatch.setattr(mini_le, "DB_FILE", str(db_file))
+    reply = mini_le.chat_response("aa")
+    assert reply
+    assert mem.events == ["chat"]
+    assert mini_le.last_metabolic_push == 1.0

--- a/tests/test_mini_le.py
+++ b/tests/test_mini_le.py
@@ -22,10 +22,12 @@ def test_load_data(tmp_path, monkeypatch):
 def test_chat_response(tmp_path, monkeypatch):
     model_file = tmp_path / "model.txt"
     data_dir = tmp_path / "data"
+    db_file = tmp_path / "memory.db"
     data_dir.mkdir()
     (data_dir / "f.txt").write_text("abcabc", encoding="utf-8")
     monkeypatch.setattr(mini_le, "MODEL_FILE", str(model_file))
     monkeypatch.setattr(mini_le, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(mini_le, "DB_FILE", str(db_file))
 
     calls = {"load": 0, "train": 0}
 


### PR DESCRIPTION
## Summary
- add BoneMemory class to track event frequencies and compute a metabolic push
- integrate BoneMemory into chat handling and metabolism, scaling novelty via metabolic push
- cover new behaviour with dedicated tests

## Testing
- `flake8 arianna_core/memory/bone_memory.py arianna_core/mini_le.py tests/test_bone_memory.py tests/test_mini_le.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e6361b3ac8329a3f32df49262ac4e