### PR TITLE
Add thread-safe EchoFeed for collective memory

### DIFF
--- a/arianna_core/collective/__init__.py
+++ b/arianna_core/collective/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for collective memory management."""
+
+from .echo_feed import EchoFeed
+
+__all__ = ["EchoFeed"]

--- a/arianna_core/collective/echo_feed.py
+++ b/arianna_core/collective/echo_feed.py
@@ -1,0 +1,40 @@
+"""Thread-safe feed to track recent text entries with metadata."""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Any, Dict, List
+
+
+class EchoFeed:
+    """Store recent text entries along with metadata in a bounded buffer.
+
+    The feed keeps only the ``maxlen`` most-recent records. Each record is a
+    dictionary with ``text`` and ``meta`` keys. Access is protected by a
+    thread lock, so multiple threads may add entries concurrently.
+    """
+
+    def __init__(self, maxlen: int):
+        self.maxlen = maxlen
+        self._buffer: List[Dict[str, Any]] = []
+        self._lock = Lock()
+
+    def add(self, text: str, meta: Dict[str, Any]) -> None:
+        """Append a new entry and trim the buffer to ``maxlen``.
+
+        Parameters
+        ----------
+        text:
+            The textual content to record.
+        meta:
+            Associated metadata for the ``text`` entry.
+        """
+        with self._lock:
+            self._buffer.append({"text": text, "meta": meta})
+            if len(self._buffer) > self.maxlen:
+                self._buffer = self._buffer[-self.maxlen :]
+
+    def last(self) -> List[Dict[str, Any]]:
+        """Return a copy of the current buffer state."""
+        with self._lock:
+            return list(self._buffer)

--- a/tests/test_echo_feed.py
+++ b/tests/test_echo_feed.py
@@ -1,0 +1,37 @@
+from threading import Thread
+
+from arianna_core.collective.echo_feed import EchoFeed
+
+
+def test_echo_feed_trims_to_maxlen():
+    feed = EchoFeed(maxlen=2)
+    feed.add("a", {"n": 1})
+    feed.add("b", {"n": 2})
+    feed.add("c", {"n": 3})
+    history = feed.last()
+    assert len(history) == 2
+    assert history[0]["text"] == "b"
+    assert history[1]["text"] == "c"
+
+
+def test_echo_feed_last_returns_copy():
+    feed = EchoFeed(maxlen=3)
+    feed.add("x", {})
+    snapshot = feed.last()
+    snapshot.append({"text": "y", "meta": {}})
+    assert len(feed.last()) == 1
+
+
+def test_echo_feed_thread_safety():
+    feed = EchoFeed(maxlen=100)
+
+    def worker(i: int) -> None:
+        feed.add(str(i), {"i": i})
+
+    threads = [Thread(target=worker, args=(i,)) for i in range(200)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(feed.last()) == 100


### PR DESCRIPTION
## Summary
- add `EchoFeed` class with locking to store recent text and metadata entries
- expose `last` to obtain a copy of the feed
- cover feed with unit tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e6516f8ac83299f6985c421ed7701