### PR TITLE
Add hashed vector RAG module with storage and search

### DIFF
--- a/arianna_core/rag/__init__.py
+++ b/arianna_core/rag/__init__.py
@@ -1,0 +1,113 @@
+"""Simple retrieval-augmented generation utilities."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Dict, Iterable, List
+
+import numpy as np
+
+from .hashed_vector import cosine, hashed_vector
+
+__all__ = ["load_corpus", "rag_search"]
+
+
+def load_corpus(paths: Iterable[str], db_path: str = "rag_vectors.db", dim: int = 256) -> None:
+    """Load text files and store hashed vectors in ``db_path``.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of file paths.
+    db_path:
+        Location of the SQLite database to create or update.
+    dim:
+        Dimensionality of the hashed vectors.
+    """
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS vectors (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT,
+            line_start INTEGER,
+            line_end INTEGER,
+            snippet TEXT,
+            vec BLOB
+        )
+        """
+    )
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    cur.execute("DELETE FROM vectors")
+    cur.execute("INSERT OR REPLACE INTO meta (key, value) VALUES ('dim', ?)", (dim,))
+
+    for path in paths:
+        path = str(path)
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        buffer: List[str] = []
+        start: int | None = None
+        for lineno, line in enumerate(lines, start=1):
+            if line.strip():
+                if start is None:
+                    start = lineno
+                buffer.append(line.rstrip("\n"))
+            elif buffer:
+                snippet = "\n".join(buffer)
+                vec = hashed_vector(snippet, dim)
+                cur.execute(
+                    "INSERT INTO vectors(path, line_start, line_end, snippet, vec) VALUES (?, ?, ?, ?, ?)",
+                    (path, start, lineno - 1, snippet, vec.tobytes()),
+                )
+                buffer = []
+                start = None
+        if buffer:
+            snippet = "\n".join(buffer)
+            vec = hashed_vector(snippet, dim)
+            cur.execute(
+                "INSERT INTO vectors(path, line_start, line_end, snippet, vec) VALUES (?, ?, ?, ?, ?)",
+                (path, start or 1, len(lines), snippet, vec.tobytes()),
+            )
+
+    conn.commit()
+    conn.close()
+
+
+def rag_search(
+    query: str,
+    k: int,
+    min_score: float,
+    db_path: str = "rag_vectors.db",
+) -> List[Dict[str, object]]:
+    """Return top ``k`` fragments matching ``query`` above ``min_score``."""
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    row = cur.execute("SELECT value FROM meta WHERE key='dim'").fetchone()
+    dim = int(row[0]) if row else 256
+    qvec = hashed_vector(query, dim)
+
+    results: List[Dict[str, object]] = []
+    for path, lstart, lend, snippet, blob in cur.execute(
+        "SELECT path, line_start, line_end, snippet, vec FROM vectors"
+    ):
+        vec = np.frombuffer(blob, dtype=np.float32)
+        if np.random.random() < 0.01:
+            vec = vec * np.random.normal(1, 0.015, size=vec.shape)
+        score = cosine(qvec, vec)
+        if score >= min_score:
+            results.append(
+                {
+                    "path": path,
+                    "lines": (lstart, lend),
+                    "snippet": snippet,
+                    "score": score,
+                }
+            )
+    conn.close()
+    results.sort(key=lambda r: r["score"], reverse=True)
+    return results[:k]

--- a/arianna_core/rag/hashed_vector.py
+++ b/arianna_core/rag/hashed_vector.py
@@ -1,0 +1,48 @@
+"""Utilities for hashed text vectors."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import numpy as np
+
+_TOKEN_RE = re.compile(r"\w+")
+
+
+def _stable_hash(token: str) -> int:
+    """Return a stable integer hash for ``token``."""
+    digest = hashlib.sha1(token.encode("utf-8")).hexdigest()
+    return int(digest, 16)
+
+
+def hashed_vector(text: str, dim: int) -> np.ndarray:
+    """Return a normalized hashed vector for ``text``.
+
+    Parameters
+    ----------
+    text:
+        Input text to vectorize.
+    dim:
+        Dimensionality of the output vector.
+    """
+
+    vec = np.zeros(dim, dtype=np.float32)
+    for token in _TOKEN_RE.findall(text.lower()):
+        idx = _stable_hash(token) % dim
+        vec[idx] += 1.0
+    norm = np.linalg.norm(vec)
+    if norm:
+        vec /= norm
+    return vec
+
+
+def cosine(a: np.ndarray, b: np.ndarray) -> float:
+    """Return cosine similarity between vectors ``a`` and ``b``."""
+    denom = np.linalg.norm(a) * np.linalg.norm(b)
+    if denom == 0:
+        return 0.0
+    return float(np.dot(a, b) / denom)
+
+
+__all__ = ["hashed_vector", "cosine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Arianna Method" }]
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
 requires-python = ">=3.8"
-dependencies = ["regex", "tomli; python_version < \"3.11\""]
+dependencies = ["regex", "numpy", "tomli; python_version < \"3.11\""]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_hashed_vector.py
+++ b/tests/test_hashed_vector.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from arianna_core.rag.hashed_vector import cosine, hashed_vector
+
+
+def test_hashed_vector_deterministic():
+    v1 = hashed_vector("Hello world", 32)
+    v2 = hashed_vector("Hello world", 32)
+    assert v1.shape == (32,)
+    assert np.allclose(v1, v2)
+
+
+def test_cosine_similarity():
+    v1 = hashed_vector("hello", 16)
+    v2 = hashed_vector("hello", 16)
+    v3 = hashed_vector("world", 16)
+    assert cosine(v1, v2) == pytest.approx(1.0)
+    assert cosine(v1, v3) < 1.0

--- a/tests/test_rag_search.py
+++ b/tests/test_rag_search.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from arianna_core.rag import load_corpus, rag_search
+
+
+def test_load_corpus_and_search(tmp_path):
+    doc = tmp_path / "doc.txt"
+    doc.write_text("Hello world.\n\nAnother line.", encoding="utf-8")
+    db = tmp_path / "vecs.db"
+    load_corpus([str(doc)], db_path=str(db), dim=32)
+    np.random.seed(0)
+    results = rag_search("hello", k=1, min_score=0.1, db_path=str(db))
+    assert results
+    top = results[0]
+    assert top["path"] == str(doc)
+    assert top["lines"] == (1, 1)
+    assert "Hello world." in top["snippet"]


### PR DESCRIPTION
## Summary
- add hashed-vector utility functions for text vectorization and cosine similarity
- persist hashed vectors for corpus snippets in SQLite and perform RAG search with slight random perturbations
- include numpy dependency and tests for hashing and RAG search

## Testing
- `ruff check arianna_core tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e652535548329889b8ceb8bb41b3c